### PR TITLE
Fixes "list of forks" link.

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -91,7 +91,7 @@ adds.
 
 # variations
 
-Check out the [list of forks](https://github.com/substack/react-starter/network/members)
+Check out the [list of forks](https://github.com/substack/react-starter-hmr/network/members)
 to see how other people have customized this starter repo.
 
 # license


### PR DESCRIPTION
The readme link was pointing to the `react-starter` project instead of the `react-starter-hmr` project.